### PR TITLE
Added a requirement for GD lib

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ a simple admin panel with an ACL using Laravel framework.
 To install this software you need:
 
   * Laravel framework 4.*
-  * Php 5.4+
+  * Php 5.4+ with GD library
 
 ## <a name="setup">Setup</a> ##
 


### PR DESCRIPTION
I added a mention that GD lib is required (line 21) because GD lib is not installed by default with PHP 5.4+ and because GD is required by gregwar/captcha 1.0.11 which is required to install this package. Without GD, this package installation fails during Setup, Step 3 "composer update". Hope that helps.
