### PR TITLE
Icons on form elements had inconsistent widths

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -88,6 +88,12 @@ div.paginator
 {
     cursor: pointer;
 }
+.centered-form .input-group {
+	width: 100%;
+}
+.centered-form .input-group-addon {
+	width: 3em;
+}
 /*///////////////// signup form ////////////////*/
 .centered-form
 {


### PR DESCRIPTION
I wanted to make the icons on the form elements match in width so they would all line up nicely.
