### PR TITLE
Fixes a small spelling mistake

### DIFF
--- a/src/Jacopo/Authentication/Validators/UserSignupValidator.php
+++ b/src/Jacopo/Authentication/Validators/UserSignupValidator.php
@@ -6,7 +6,7 @@ use Jacopo\Library\Validators\OverrideConnectionValidator;
 class UserSignupValidator extends OverrideConnectionValidator
 {
   protected static $messages = [
-      "mail_signup" => "an user with that email already exists."
+      "mail_signup" => "A user with that email already exists."
   ];
 
   protected static $rules = [


### PR DESCRIPTION
Just a little thing, but I thought I would help. The word "user" does start with the vowel U, but it is pronounced like the consonant Y (which is sometimes a vowel too so that doesn't really help much). So it reads like it should be "an user", but it is actually "a user". I've spent way too much time on this already haven't I? LOL. Hope it helps.
