### PR TITLE
Bug: fails on group create/edit with error.

### DIFF
--- a/src/controllers/GroupController.php
+++ b/src/controllers/GroupController.php
@@ -71,7 +71,7 @@ class GroupController extends \Controller
         {
             $errors = $this->f->getErrors();
             // passing the id incase fails editing an already existing item
-            return Redirect::route("users.groups.edit", $id ? ["id" => $id]: [])->withInput()->withErrors($errors);
+            return Redirect::route("groups.edit", $id ? ["id" => $id]: [])->withInput()->withErrors($errors);
         }
         return Redirect::action('Jacopo\Authentication\Controllers\GroupController@editGroup',["id" => $obj->id])->withMessage(Config::get('laravel-authentication-acl::messages.flash.success.group_edit_success'));
     }


### PR DESCRIPTION
To reproduce, create a new group using page /admin/groups/edit. If you hit submit with an empty group name you get an error,

Error: InvalidArgumentException Route [users.groups.edit] not defined.

This bug affects all cases where an error might occur during group create or edit. I've proposed a change to the route in the redirect from "users.groups.edit" to "groups.edit".

I hope that's an appropriate solution. Maybe there's a better one?
