### PR TITLE
Adding new invitation process for admins when they create new users.

### DIFF
--- a/src/Jacopo/Authentication/Models/UserProfile.php
+++ b/src/Jacopo/Authentication/Models/UserProfile.php
@@ -24,7 +24,8 @@ class UserProfile extends BaseModel
         'zip',
         'code',
         'address',
-        'avatar'
+        'avatar',
+        'timezone'
     ];
 
     protected $guarded = ["id"];

--- a/src/Jacopo/Authentication/Models/UserProfile.php
+++ b/src/Jacopo/Authentication/Models/UserProfile.php
@@ -25,7 +25,8 @@ class UserProfile extends BaseModel
         'code',
         'address',
         'avatar',
-        'timezone'
+        'timezone',
+        'username'
     ];
 
     protected $guarded = ["id"];

--- a/src/views/admin/mail/welcome-new-user.blade.php
+++ b/src/views/admin/mail/welcome-new-user.blade.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    {{ HTML::style('packages/jacopo/laravel-authentication-acl/css/mail-base.css') }}
+    {{ HTML::style('//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css') }}
+</head>
+<body>
+   <h2>Invitation to join {{Config::get('laravel-authentication-acl::app_name')}}</h2>
+<div>
+    <strong>{{ $body['admin_name'] }} has created an account for you. Before you can use it you'll need to create a password using the link below.</strong>
+	<br/>
+	<br/>
+    <strong>Your new account details: </strong>
+    <ul>
+        <li>Username: {{$body['email']}}</li>
+		<li>Password: <a href="{{URL::action('Jacopo\Authentication\Controllers\AuthController@getChangePassword', ['token' => $body['token'], 'email' => $body['email'] ] )}}">Create Password</a></li>
+    </ul>
+	<p>The password link is only valid for 24 hours. If you miss this opportunity use the <a href="{{ URL::to('user/recover-password') }}">"Forgot Password"</a> link on the login page.</p>
+</div>
+</body>
+</html>

--- a/src/views/admin/user/edit.blade.php
+++ b/src/views/admin/user/edit.blade.php
@@ -41,15 +41,16 @@ Admin area: edit user
                         {{Form::text('email', null, ['class' => 'form-control', 'placeholder' => 'user email', 'autocomplete' => 'off'])}}
                     </div>
                     <span class="text-danger">{{$errors->first('email')}}</span>
+				@if(!empty($user->id))
                     <!-- password text field -->
                     <div class="form-group">
-                        {{Form::label('password',isset($user->id) ? "Change password: " : "Password: ")}}
+                        {{Form::label('password', "Change password: " )}}
                         {{Form::password('password', ['class' => 'form-control', 'autocomplete' => 'off', 'placeholder' => ''])}}
                     </div>
                     <span class="text-danger">{{$errors->first('password')}}</span>
                     <!-- password_confirmation text field -->
                     <div class="form-group">
-                        {{Form::label('password_confirmation',isset($user->id) ? "Confirm change password: " : "Confirm password: ")}}
+                        {{Form::label('password_confirmation', "Confirm change password: " )}}
                         {{Form::password('password_confirmation', ['class' => 'form-control', 'placeholder' => '','autocomplete' => 'off'])}}
                     </div>
                     <span class="text-danger">{{$errors->first('password_confirmation')}}</span>
@@ -57,17 +58,30 @@ Admin area: edit user
                         {{Form::label("activated","User active: ")}}
                         {{Form::select('activated', ["1" => "Yes", "0" => "No"], (isset($user->activated) && $user->activated) ? $user->activated : "0", ["class"=> "form-control"] )}}
                     </div>
+				@endif
                     <div class="form-group">
                         {{Form::label("banned","Banned: ")}}
                         {{Form::select('banned', ["1" => "Yes", "0" => "No"], (isset($user->banned) && $user->banned) ? $user->banned : "0", ["class"=> "form-control"] )}}
                     </div>
+				@if(empty($user->id))
+                    <!-- send_welcome_email checkbox -->
+                    <div class="form-group">
+                        {{Form::label('send_welcome_email', "Send welcome email: " )}}
+                        {{Form::select('send_welcome_email', ["1" => "Yes", "0" => "No"], "1", ["class"=> "form-control"] )}}
+                    </div>
+				@endif
                     {{Form::hidden('id')}}
                     {{Form::hidden('form_name','user')}}
-                    <a href="{{URL::action('Jacopo\Authentication\Controllers\UserController@deleteUser',['id' => $user->id, '_token' => csrf_token()])}}" class="btn btn-danger pull-right margin-left-5 delete">Delete user</a>
+				@if(!empty($user->id))
+                    <a href="{{URL::action('Jacopo\Authentication\Controllers\UserController@deleteUser',['id' => $user->id, '_token' => csrf_token()])}}" class="btn btn-danger margin-left-5 delete">Delete user</a>
+				@endif
+
                     {{Form::submit('Save', array("class"=>"btn btn-info pull-right "))}}
                     {{Form::close()}}
                     </div>
+
                     <div class="col-md-6 col-xs-12">
+				@if(!empty($user->id))
                         <h4><i class="fa fa-users"></i> Groups</h4>
                         @include('laravel-authentication-acl::admin.user.groups')
 
@@ -75,6 +89,7 @@ Admin area: edit user
                         <h4><i class="fa fa-lock"></i> Permission</h4>
                         {{-- permissions --}}
                         @include('laravel-authentication-acl::admin.user.perm')
+				@endif
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Please review UserController.php at line #118 for the private function sendWelcomeMail($new_user) as I'm not sure if this is the most suitable location for this.

Also note that for add user view page I made substantial changes to hide all non-relevant input fields for the add user view eg. groups, permissions, etc.. have been hidden until after the user is created and the admin is redirected to the user edit page. I also added a new select to determine if the welcome email is to be sent to the new user or not. I decided to leave the "ban user" select in as that might come in handy to proactively ban a user that hasn't yet registered.

I might revisit this process again and give the admin the ability to assign group(s) and permission(s) to a new user all in one step.
