### PR TITLE
user_login_redirect_url settings is not reflected in client authentication

### DIFF
--- a/app/Authentication/Controllers/AuthController.php
+++ b/app/Authentication/Controllers/AuthController.php
@@ -65,7 +65,7 @@ class AuthController extends Controller {
             return Redirect::route("user.login")->withInput()->withErrors($errors);
         }
 
-        return Redirect::to(Config::get('acl_config.user_login_redirect_url'));
+        return Redirect::to(Config::get('acl_base.user_login_redirect_url'));
     }
 
     /**


### PR DESCRIPTION
Hi.
I found a problem that is not redirected to configuration path after a client authentication successful.

Case
- Edit: [Application Root]/config/acl_base.php
  - "user_login_redirect_url" => "hoge",
- Access client login page
  - http://xxxx/[Application]/
- Authentication success. 
  - Expected to be redirect to http://xxx/[Application]/hoge
  - But redirect to http://xxx/[Application]/ 

My Environment
- OS: CentOS Linux release 7.0.1406
- PHP: 5.6.8
- Laravel Framework: 5.0.27

Kind regards
hitaka0214
