### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+composer.lock
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y software-properties-common
+
+RUN apt-get -y install curl netcat wget telnet vim bzip2 ssmtp locales bash-completion net-tools iputils-ping \
+    build-essential git libfreetype6-dev libpng-dev libzmq3-dev pkg-config python-dev python-numpy python-pip software-properties-common swig zip sudo unzip git-core software-properties-common sqlite systemd \
+    && locale-gen en_US.utf8 \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 
+
+ENV \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    TZ=Europe/Madrid \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get install -y  php php-dev libmcrypt-dev php-pear php-fpm php-mbstring php-xml php-mysql php-json php-intl php-opcache php-gd php-readline php-curl php-gmp php7.2-sqlite
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php composer-setup.php
+RUN php -r "unlink('composer-setup.php');"
+RUN mv composer.phar /usr/bin/composer
+RUN echo 'alias ll="ls -lha"' >> ~/.bashrc
+RUN  pecl channel-update pecl.php.net
+RUN  pecl install mcrypt-1.0.1
+RUN echo "extension=mcrypt.so" >> /etc/php/7.2/cli/php.ini
+RUN echo "extension=mcrypt.so" >> /etc/php/7.2/fpm/php.ini
+
+RUN echo "mysql-server mysql-server/root_password password toor" | debconf-set-selections
+RUN echo "mysql-server mysql-server/root_password_again password toor" | debconf-set-selections
+
+RUN apt-get update && \
+    apt-get -y install mysql-server sphinxsearch && \
+    mkdir -p /var/lib/mysql && \
+    mkdir -p /var/run/mysqld && \
+    mkdir -p /var/log/mysql && \
+    chown -R mysql:mysql /var/lib/mysql && \
+    chown -R mysql:mysql /var/run/mysqld && \
+    chown -R mysql:mysql /var/log/mysql && \
+    sed -i -e "$ a [client]\n\n[mysql]\n\n[mysqld]"  /etc/mysql/my.cnf && \
+    sed -i -e "s/\(\[client\]\)/\1\ndefault-character-set = utf8/g" /etc/mysql/my.cnf && \
+    sed -i -e "s/\(\[mysql\]\)/\1\ndefault-character-set = utf8/g" /etc/mysql/my.cnf && \
+    sed -i -e "s/\(\[mysqld\]\)/\1\ninit_connect='SET NAMES utf8'\ncharacter-set-server = utf8\ncollation-server=utf8_unicode_ci\nbind-address = 0.0.0.0/g" /etc/mysql/my.cnf && \
+    service mysql start && sleep 10 && \
+    mysql --user=root --password=toor -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'toor' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+
+VOLUME /var/lib/mysql
+
+RUN sudo systemctl enable mysql
+
+RUN mkdir /app
+WORKDIR /app
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ You can see the full documentation and usage [here](docs/index.md)
 ####Interested in some new feature?
 There's something you like to see in this package?
 Contact me and i'll do my best to implement that in next releases.
+
+### Running with docker:
+
+Running with docker (PHP 7.2)
+
+    docker build -t acl .
+    docker run --name acl-container -v $(pwd):/app -it acl
+    docker exec -i -t acl-container bash
+    

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "intervention/image": "2.*",
     "cartalyst/sentry": "2.1.*",
     "jacopo/laravel-library": "1.2.*",
-    "gregwar/captcha": "1.0.11"
+    "gregwar/captcha": "1.1.7"
   },
   "require-dev": {
     "mockery/mockery": "0.9.0",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+service mysql start
+
+cd /app/
+composer install
+
+tail -F /dev/null
+


### PR DESCRIPTION
This PR updates the `gregwar/captcha` dependency to the latest version, which is compatible with `PHP >= 7.2`. It also adds a Dockerfile and instructions to run it, which I used to test the package in PHP 7.2